### PR TITLE
Call to correct methods for getting prefixed tables

### DIFF
--- a/Helper/ExtraConfig.php
+++ b/Helper/ExtraConfig.php
@@ -33,7 +33,7 @@ class ExtraConfig
     {
         $data = array();
         $dbConnection = $this->dbObject->getConnection();
-        $prefixedTableName = $dbConnection->getTableName(self::CONFIG_TABLE);
+        $prefixedTableName = $this->dbObject->getTableName(self::CONFIG_TABLE);
         if ($dbConnection->isTableExists($prefixedTableName)) {
             $result = $dbConnection->fetchAll("select * from $prefixedTableName");
             if (count($result)) {

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -50,7 +50,7 @@ class InstallData implements InstallDataInterface
      */
     public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {
-        $prefixedTableName = $setup->getConnection()->getTableName(self::CONFIG_TABLE);
+        $prefixedTableName = $setup->getTable(self::CONFIG_TABLE);
         if ($setup->tableExists($prefixedTableName)) {
             foreach ($this->defaultConfigs as $config => $value) {
                 $setup->getConnection()

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -55,8 +55,8 @@ class UpgradeData implements UpgradeDataInterface
     public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {
         $setup->startSetup();
-        $prefixedTableName = $setup->getConnection()->getTableName(self::CONFIG_TABLE);
-        $prefixedOrdersTableName = $setup->getConnection()->getTableName(self::ORDERS_TABLE);
+        $prefixedTableName = $setup->getTable(self::CONFIG_TABLE);
+        $prefixedOrdersTableName = $setup->getTable(self::ORDERS_TABLE);
         if ($setup->tableExists($prefixedTableName)) {
             if (version_compare($context->getVersion(), '8.3.1') < 0) {
                 $newConfigs = array(


### PR DESCRIPTION
Issue closed: https://github.com/pagantis/magento-2X/pull/56
The new issue for corrections: https://github.com/pagantis/magento-2X/issues/60

The previously used methods returned the tables without a prefix. 
Fixed to call to correct methods for getting prefixed tables. 