### PR TITLE
Fix Mysql Problem: Set key field not nullable

### DIFF
--- a/Controller/Payment/Index.php
+++ b/Controller/Payment/Index.php
@@ -389,7 +389,7 @@ class Index extends Action
             $table = $dbConnection
                 ->newTable($tableName)
                 ->addColumn('id', Table::TYPE_INTEGER, 10, array('primary'=>true, 'nullable' => false))
-                ->addColumn('order_id', Table::TYPE_TEXT, 50, array('primary'=>true, 'nullable' => true))
+                ->addColumn('order_id', Table::TYPE_TEXT, 50, array('primary'=>true, 'nullable' => false))
                 ->addColumn('mg_order_id', Table::TYPE_TEXT, 50)
                 ->addColumn('token', Table::TYPE_TEXT, 32);
             return $dbConnection->createTable($table);


### PR DESCRIPTION
Issue: 
Problem creating table "cart_process" (mysql error):
https://github.com/pagantis/magento-2X/issues/62

Fixes issue by marking the key as non-nullable.

